### PR TITLE
scripts composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,14 @@
         }
     },
     "scripts": {
+        "test": "./vendor/bin/phpunit",
+        "permissions": "sudo chown $USER:$USER -R .",
+        "docker-up": "cd ../laradock && docker-compose up -d nginx mysql phpmyadmin workspace && cd -",
+        "docker-down": "cd ../laradock && docker-compose down && cd -",
+        "bash": "cd ../laradock && docker-compose exec --user=laradock workspace bash && cd -",
+        "tinker": "cd ../laradock && docker-compose exec --user=laradock workspace php ./laratdd/artisan tinker && cd -",
+        "db:seed": "cd ../laradock && docker-compose exec --user=laradock workspace php ./laratdd/artisan db:seed && cd -",
+        "route:list": "cd ../laradock && docker-compose exec --user=laradock workspace php ./laratdd/artisan route:list && cd -",
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],


### PR DESCRIPTION

script creados para levantar, apagar docker con composer y ejecutar algunos comandos de artisan pero sobre todo para entrar a la terminal siendo el propietario laradock y no root, ya que he tenido problemas para luego desde el IDE manipular lo creado mediante la terminal, puesto que con el comando ejecutado en clase para ello, nos conectamos como root y luego en el IDE no podemos manipular nada.

**Ejemplo:**:

Si nos conectamos como comentamos en clase: `docker-compose exec workspace bash` entraríamos dentro de docker como **root**, para evitar esto habría que modificar el comando de la siguiente forma `docker-compose exec --user=laradock workspace bash` esto nos permitiría conectarnos como un usuario sin privilegios de administrador. [Link donde se ve ejemplo](https://stackoverflow.com/questions/68029209/pass-shell-bash-commands-to-docker).

Con los Scripts que he añadido, podríamos usar el siguiente:

```
composer run bash
```

Y esto nos permitiría conectarnos al contenedor como si fuéramos el usuario `laradock`.


En el caso de que hayamos ya creado algún controlador como **root** he creado un script que es:

```
composer run permissions
```

Que lo que haría sería modificar los permisos del proyecto entero, para que sean los del usuario que tiene la sesión iniciada. Esto nos permitiría editar los ficheros a los que no teníamos permiso de modificar antes.

Por otro lado he creado dos scripts para hacernos las vída más sencilla:
```
composer run docker-up
composer run docker-down
```

Que como su nombre indica se encargan de levantar y tumbar los contenedores de docker.


Por último he dejado alguno ejemplo de como podríamos hacer llamadas a `php artisan` desde fuera del docker sin necesidad de conectarnos directamente.
Ejemplos:

```
composer run tinker
composer run db:seed
composer run route:list
```



